### PR TITLE
README.md: fix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Subject Line Length
-        uses: tim-actions/commit-message-checker-with-regex@v1.0.0
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^.{0,75}(\n.*)*$'


### PR DESCRIPTION
In my previous PR https://github.com/tim-actions/commit-message-checker-with-regex/pull/1
I made a mistake of using `v1.0.0` instead of `v0.1.0` in one place. This PR fixes that.

PS can you please enable "Issues" for this repo? I want to report a problem but can't;
thus I am reporting it below.

-----

There is a tag 'v1' in this repo (https://github.com/tim-actions/commit-message-checker-with-regex/releases/tag/v1)
which I think needs to be removed as the latest version is v0.3.1 and v1 > v0,
so dependabot suggest to update from v0.3.1 to v1 which is obviously wrong.

To fix this, `v1` tag need to be removed.

Alternatively, you can release say v1.1 or so and that will fix the issue
(an update to README.md is required).