### PR TITLE
Change Node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: "false"
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: 'check'


### PR DESCRIPTION
Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases).